### PR TITLE
Development

### DIFF
--- a/pokie/cache/redis.py
+++ b/pokie/cache/redis.py
@@ -9,11 +9,7 @@ from pokie.constants import DI_REDIS
 
 class RedisCache(BaseRedisCache, Injectable):
     def __init__(self, di: Di):
-        # base class init is completely overridden
         if not di.has(DI_REDIS):
             raise RuntimeError("DI_REDIS not found; maybe RedisFactory is missing?")
         self.set_di(di)
-        self._serialize = pickle.dumps
-        self._deserialize = pickle.loads
-        self._prefix = None
-        self._redis = di.get(DI_REDIS)
+        super().__init__(backend=di.get(DI_REDIS))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rick-db>=2.0.0
-rick>=0.7.0
+rick>=0.8.0
 rick-mailer>=1.1.1
 Flask>=3.1.0
 Werkzeug

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = true
 zip_safe = false
 install_requires =
     rick-db>=2.0.2
-    rick>=0.7.0
+    rick>=0.8.0
     rick-mailer>=1.1.1
     Flask>=3.1.0
     Werkzeug

--- a/tests/cache/test_redis.py
+++ b/tests/cache/test_redis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pokie.cache import MemoryCache, RedisCache
-
+from pokie.constants import DI_REDIS
 
 @pytest.fixture
 def redis_cache(pokie_di):


### PR DESCRIPTION
## Summary by Sourcery

Simplify RedisCache initialization by delegating to the base class, update the rick dependency to 0.8.0, and adjust the RedisCache test import.

Enhancements:
- Simplify RedisCache __init__ by passing the Redis backend to the base class constructor instead of overriding internal attributes.

Tests:
- Add DI_REDIS import to RedisCache test fixture.

Chores:
- Bump rick dependency to >=0.8.0 in requirements.txt and setup.cfg.