### PR TITLE
change default redis password to None

### DIFF
--- a/pokie/constants.py
+++ b/pokie/constants.py
@@ -1,5 +1,5 @@
 # Version
-POKIE_VERSION = ["0", "9", "5"]
+POKIE_VERSION = ["0", "9", "6"]
 
 
 def get_version():

--- a/pokie/core/factories/redis.py
+++ b/pokie/core/factories/redis.py
@@ -26,7 +26,7 @@ def RedisFactory(_di: Di):
         redis_cfg = {
             "host": cfg.get(CFG_REDIS_HOST, "localhost"),
             "port": int(cfg.get(CFG_REDIS_PORT, 6379)),
-            "password": cfg.get(CFG_REDIS_PASSWORD, ""),
+            "password": cfg.get(CFG_REDIS_PASSWORD, None),
             "db": int(cfg.get(CFG_REDIS_DB, 0)),
             "ssl": True if cfg.get(CFG_REDIS_SSL, None) == "1" else False,
         }


### PR DESCRIPTION
## Summary by Sourcery

Bump the library version and adjust the Redis factory to default to no password when none is configured.

Enhancements:
- Change the Redis connection factory to use a None default for the password configuration instead of an empty string.

Chores:
- Increment the project version constant from 0.9.5 to 0.9.6.