### PR TITLE
Resolve cli commands by module load order; provision test services with testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       REDIS_HOST: localhost
       REDIS_PORT: 6379
       REDIS_PASSWORD: myRedisPassword
+      # the `services:` block above already provides both; the suite otherwise
+      # starts its own containers for local runs (see tests/conftest.py)
+      POKIE_TEST_CONTAINERS: "0"
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- CLI command resolution follows module load order, so a command declared by an application module now overrides one declared by an earlier module — the same precedence services already use. `cli_runner()` dispatched to the **first** module declaring a command while `list`/`help` described the **last**, so an overridden command was documented by one class and executed by another; and since `system_modules` (`pokie.contrib.base`) always load first, its commands could not be overridden at all
+
+### Added
+- `FlaskApplication.get_command_map()` and `FlaskApplication.resolve_command()` — the single source of truth for command-name to handler resolution. `BaseCommand.get_cmd_map()` delegates to it, so listing, help and execution cannot disagree
+
 ## [1.1.1] - 2026-06-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Added
 - `FlaskApplication.get_command_map()` and `FlaskApplication.resolve_command()` — the single source of truth for command-name to handler resolution. `BaseCommand.get_cmd_map()` delegates to it, so listing, help and execution cannot disagree
 
+### Changed
+- The test suite provisions its own PostgreSQL and Redis with testcontainers, so `python main.py pytest` needs only Docker — no local PostgreSQL and no credentials in `env.sh`. Set `POKIE_TEST_CONTAINERS=0` to use services you provide instead (`TEST_DB_*` / `REDIS_*`), which is what CI and tox do since both already start their own. `testcontainers[postgres,redis]` is a dev dependency; without it installed the suite falls back to the environment as before
+
 ## [1.1.1] - 2026-06-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,18 @@ python main.py pytest tests/core/test_job_runner.py -v
 python main.py pytest -k "test_cors"
 ```
 
-Tests require a running PostgreSQL instance. The test plugin automatically creates/drops the
-`pokie_test` database. Configuration comes from environment variables (see `env.sh`).
+Tests require **Docker**, nothing else: `tests/conftest.py` starts PostgreSQL and Redis with
+testcontainers for the session, and the test plugin creates/drops the `pokie_test` database
+inside it. No local PostgreSQL, no credentials in `env.sh`.
+
+To point the suite at services you provide instead, set `POKIE_TEST_CONTAINERS=0` and supply
+`TEST_DB_*` / `REDIS_*` — which is what CI (`.github/workflows/ci.yml`) and tox (`tox.ini`,
+via tox-docker) do, since both already start their own. The credentials are identical either
+way, so no test can depend on which mechanism provisioned it.
+
+Note `pokie_app` is an **autouse** fixture, so every test builds the application and gets a
+freshly migrated database; a broken database configuration fails the whole suite, not just the
+database-backed part of it.
 
 Do NOT run tests with bare `pytest` - always use `python main.py pytest` which loads the
 Pokie test plugin that provides fixtures (`pokie_app`, `pokie_di`, `pokie_db`,
@@ -70,6 +80,12 @@ deserialization via `RequestRecord`, and `JsonResponse` for consistent API respo
 
 ### CLI Commands
 Extend `CliCommand`. Register in module's `cmd` dict as `"command:name": "path.to.Class"`.
+
+Command names resolve in **module load order, last one wins** — the same precedence as
+services — so an application module can override a command declared by an earlier module,
+including the `pokie.contrib.base` commands (system modules always load first). Resolution
+goes through `FlaskApplication.get_command_map()` / `resolve_command()`; use those rather
+than walking `modules[*].cmd` yourself, or listing and execution will disagree.
 
 ### Tests
 - Test classes: `class TestXxx:` with `def test_xxx(self, fixture):` methods

--- a/pokie/contrib/base/cli/base.py
+++ b/pokie/contrib/base/cli/base.py
@@ -16,33 +16,30 @@ class BaseCommand(CliCommand):
         return self.get_di().get(DI_APP).modules
 
     def get_cmd_map(self) -> dict:
-        result = {}
-        for _, module in self.get_modules().items():
-            for cmd, cmd_class in module.cmd.items():
-                result[cmd] = cmd_class
-        return result
+        # delegated so listing, help and execution can never disagree on which
+        # class handles a command that more than one module declares
+        return self.get_di().get(DI_APP).get_command_map()
 
     def run(self, args) -> bool:
         di = self.get_di()
         color = AnsiColor()
         self.tty.write("Available commands:\n")
-        for _, module in di.get(DI_APP).modules.items():
-            for cmd, cmd_path in module.cmd.items():
-                cls = load_class(cmd_path)
-                if not cls:
-                    raise RuntimeError(
-                        "Error: class '{}' not found while listing available CLI commands".format(
-                            cmd_path
-                        )
+        for cmd, cmd_path in self.get_cmd_map().items():
+            cls = load_class(cmd_path)
+            if not cls:
+                raise RuntimeError(
+                    "Error: class '{}' not found while listing available CLI commands".format(
+                        cmd_path
                     )
-                if not issubclass(cls, CliCommand):
-                    raise RuntimeError(
-                        "Error: class '{}' does not extend CliCommand".format(cmd_path)
-                    )
-                obj = cls(di)
-                self.tty.write(
-                    "{} \t {}".format(color.green(cmd), color.white(obj.description))
                 )
+            if not issubclass(cls, CliCommand):
+                raise RuntimeError(
+                    "Error: class '{}' does not extend CliCommand".format(cmd_path)
+                )
+            obj = cls(di)
+            self.tty.write(
+                "{} \t {}".format(color.green(cmd), color.white(obj.description))
+            )
 
         return True
 

--- a/pokie/core/application.py
+++ b/pokie/core/application.py
@@ -2,7 +2,7 @@ import os
 import sys
 import threading
 import time
-from typing import List
+from typing import List, Optional
 
 from flask import Flask
 from rick.base import Di, Container, MapLoader
@@ -277,36 +277,61 @@ class FlaskApplication:
         parser = ArgParser(**kwargs)
 
         # lookup handler
-        for _, module in self.modules.items():
-            if command in module.cmd.keys():
-                handler = load_class(module.cmd[command], raise_exception=True)
+        handler_path = self.resolve_command(command)
+        if handler_path is None:
+            # command not found
+            tty.error("error executing '{}': command not found".format(command))
+            return self.CLI_CMD_NOT_FOUND
 
-                if not issubclass(handler, CliCommand):
-                    raise RuntimeError(
-                        "cli(): command handler does not extend CliCommand"
-                    )
+        handler = load_class(handler_path, raise_exception=True)
 
-                handler = handler(self.di, writer=tty)  # type: CliCommand
-                if not handler.skipargs:  # skipargs controls usage of argparser
-                    handler.arguments(parser)
-                    args = parser.parse_args(args)
-                    if parser.failed:
-                        # invalid/insufficient args
-                        tty.error(parser.error_message)
-                        parser.print_help(tty.stderr)
-                        return self.CLI_CMD_FAILED
-                else:
-                    # skipargs is true, all argparsing is ignored
-                    # this allow for custom cli arg handling
-                    args = None
+        if not issubclass(handler, CliCommand):
+            raise RuntimeError("cli(): command handler does not extend CliCommand")
 
-                if handler.run(args):
-                    return self.CLI_CMD_SUCCESS
+        handler = handler(self.di, writer=tty)  # type: CliCommand
+        if not handler.skipargs:  # skipargs controls usage of argparser
+            handler.arguments(parser)
+            args = parser.parse_args(args)
+            if parser.failed:
+                # invalid/insufficient args
+                tty.error(parser.error_message)
+                parser.print_help(tty.stderr)
                 return self.CLI_CMD_FAILED
+        else:
+            # skipargs is true, all argparsing is ignored
+            # this allow for custom cli arg handling
+            args = None
 
-        # command not found
-        tty.error("error executing '{}': command not found".format(command))
-        return self.CLI_CMD_NOT_FOUND
+        if handler.run(args):
+            return self.CLI_CMD_SUCCESS
+        return self.CLI_CMD_FAILED
+
+    def get_command_map(self) -> dict:
+        """
+        Map of cli command name -> handler class path, across every module
+
+        Modules are traversed in load order and later entries REPLACE earlier ones,
+        so an application module can override a command declared by a system module
+        (system modules are always loaded first, see build()). That is the same
+        precedence services use, and the mechanism intended for customization.
+
+        This is also the map 'list' and 'help' have always been built from; before,
+        cli_runner() resolved a command by taking the FIRST module declaring it, so
+        an overridden command was described by one class and executed by another.
+        :return: dict
+        """
+        result = {}
+        for _, module in self.modules.items():
+            result.update(module.cmd)
+        return result
+
+    def resolve_command(self, command: str) -> Optional[str]:
+        """
+        Resolve a cli command name to its handler class path
+        :param command: command name
+        :return: class path, or None if the command does not exist
+        """
+        return self.get_command_map().get(command, None)
 
     def cli(self, **kwargs):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
 pytest==9.0.3
 pytest-cov==7.1.0
 pytest-testdox==3.1.0
+# provisions PostgreSQL + Redis for a local `python main.py pytest`; CI and tox
+# start their own services and opt out with POKIE_TEST_CONTAINERS=0
+testcontainers[postgres,redis]==4.15.0
 flake8==7.3.0
 flake8_black==0.4.0
 coverage==7.14.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,108 @@
+import os
+
+import pytest
+
 pytest_plugins = [
     "tests.unit.fixtures",
 ]
+
+# Test services.
+#
+# `python main.py pytest` used to need a hand-provisioned PostgreSQL plus matching
+# credentials in env.sh. That is a setup step per developer machine, and when it
+# drifts the whole suite fails rather than the database-backed part of it: the
+# plugin's `pokie_app` fixture is autouse, so a bad password errors even tests that
+# never touch a database. Containers remove the step — a clean checkout with Docker
+# running is enough.
+#
+# CI (.github/workflows/ci.yml) and tox (tox.ini) already start their own services,
+# so they set POKIE_TEST_CONTAINERS=0 and keep using them; the credentials below
+# deliberately match theirs so a test cannot depend on which mechanism provisioned it.
+
+POSTGRES_IMAGE = "postgres:14-alpine"
+REDIS_IMAGE = "redis:7-alpine"
+
+DB_NAME = "test_pokie"
+DB_USER = "pokieUser"
+DB_PASSWORD = "somePassword"
+
+_DISABLED = ("0", "false", "no", "off")
+
+
+def _containers_enabled() -> bool:
+    """Should this session provision its own services?
+
+    Explicitly disabled wins. Otherwise containers are used when testcontainers is
+    importable, and when it is not we stay out of the way and leave whatever
+    TEST_DB_* / REDIS_* the environment already carries — which is what an
+    installation without the dev extras, or a developer pointing at their own
+    database, has.
+    """
+    if os.getenv("POKIE_TEST_CONTAINERS", "").strip().lower() in _DISABLED:
+        return False
+    try:
+        import testcontainers  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _load_containers():
+    try:  # testcontainers >= 4.15
+        from testcontainers.community.postgres import PostgresContainer
+        from testcontainers.community.redis import RedisContainer
+    except ImportError:  # older layout, deprecated in 4.15
+        from testcontainers.postgres import PostgresContainer
+        from testcontainers.redis import RedisContainer
+    return PostgresContainer, RedisContainer
+
+
+@pytest.fixture(scope="session", autouse=True)
+def pokie_test_services():
+    """Provision PostgreSQL and Redis for the session, and publish their addresses.
+
+    Session-scoped AND autouse so it is set up before `pokie_app`, the
+    function-scoped autouse fixture in `pokie.test.plugin` that builds the
+    application under test. With TEST_SHARE_CTX false (the default) `pokie_app`
+    re-runs `build_pokie()`, so the environment set here is the configuration the
+    application reads — which is why this sets environment variables rather than
+    poking at an already-built config container.
+    """
+    if not _containers_enabled():
+        yield
+        return
+
+    postgres_cls, redis_cls = _load_containers()
+
+    postgres = postgres_cls(
+        POSTGRES_IMAGE, username=DB_USER, password=DB_PASSWORD, dbname=DB_NAME
+    )
+    redis = redis_cls(REDIS_IMAGE)
+
+    with postgres, redis:
+        db_host = postgres.get_container_host_ip()
+        db_port = str(postgres.get_exposed_port(5432))
+
+        # what the test plugin uses to create/drop the per-run database
+        os.environ["TEST_DB_HOST"] = db_host
+        os.environ["TEST_DB_PORT"] = db_port
+        os.environ["TEST_DB_NAME"] = DB_NAME
+        os.environ["TEST_DB_USER"] = DB_USER
+        os.environ["TEST_DB_PASSWORD"] = DB_PASSWORD
+        os.environ["TEST_DB_SSL"] = "0"
+
+        # PgSqlFactory reads DB_*; kept in step so a test that resolves DI_DB before
+        # the plugin replaces it does not reach for a database that is not there
+        os.environ["DB_HOST"] = db_host
+        os.environ["DB_PORT"] = db_port
+        os.environ["DB_NAME"] = DB_NAME
+        os.environ["DB_USER"] = DB_USER
+        os.environ["DB_PASSWORD"] = DB_PASSWORD
+        os.environ["DB_SSL"] = "0"
+
+        os.environ["REDIS_HOST"] = redis.get_container_host_ip()
+        os.environ["REDIS_PORT"] = str(redis.get_exposed_port(6379))
+        os.environ["REDIS_PASSWORD"] = ""
+        os.environ["REDIS_SSL"] = "0"
+
+        yield

--- a/tests/unit/test_cli_override.py
+++ b/tests/unit/test_cli_override.py
@@ -1,0 +1,212 @@
+import io
+import threading
+
+from rick.base import Di
+from rick.resource.console import ConsoleWriter
+
+from pokie.constants import DI_APP, DI_TTY
+from pokie.contrib.base.cli.base import BaseCommand, HelpCmd, ListCmd
+from pokie.core import CliCommand
+from pokie.core.application import FlaskApplication
+from pokie.core.module import BaseModule
+
+HERE = "tests.unit.test_cli_override"
+
+# commands append their tag here when run, so a test can assert WHICH class the
+# dispatcher picked rather than only that something succeeded
+EXECUTED = []
+
+
+class RecordingCmd(CliCommand):
+    tag = "recording"
+    result = True
+
+    def run(self, args) -> bool:
+        EXECUTED.append(self.tag)
+        return self.result
+
+
+# NOTE: no description here may contain a command NAME — one of the tests below
+# counts occurrences of "db:update" in the rendered listing.
+class SystemDbUpdateCmd(RecordingCmd):
+    description = "the update command as declared by the system module"
+    tag = "system"
+
+
+class AppDbUpdateCmd(RecordingCmd):
+    description = "the update command as declared by the application module"
+    tag = "app"
+
+
+class SystemListCmd(RecordingCmd):
+    description = "a command only the system module declares"
+    tag = "system-list"
+
+
+class AppCustomCmd(RecordingCmd):
+    description = "a command only the application module declares"
+    tag = "app-custom"
+
+
+class FailingCmd(RecordingCmd):
+    description = "a command that reports failure"
+    tag = "failing"
+    result = False
+
+
+class SystemModule(BaseModule):
+    name = "system"
+    description = "a system module, always loaded first"
+    cmd = {
+        "db:update": HERE + ".SystemDbUpdateCmd",
+        "list": HERE + ".SystemListCmd",
+    }
+
+
+class AppModule(BaseModule):
+    name = "app"
+    description = "an application module"
+    cmd = {
+        "db:update": HERE + ".AppDbUpdateCmd",
+        "custom": HERE + ".AppCustomCmd",
+    }
+
+
+class FailingModule(BaseModule):
+    name = "failing"
+    description = "declares a command that returns False"
+    cmd = {"boom": HERE + ".FailingCmd"}
+
+
+def _writer():
+    return ConsoleWriter(stdout=io.StringIO(), stderr=io.StringIO())
+
+
+def _app(*modules) -> FlaskApplication:
+    """An application with just enough state to resolve and run cli commands."""
+    app = FlaskApplication.__new__(FlaskApplication)
+    app.modules = {m.name: m.__new__(m) for m in modules}
+    app.di = Di()
+    app.lock = threading.Lock()
+    app.pre_cli_hooks = []
+    app._cli_initialized = True
+    app.di.add(DI_APP, app)
+    app.di.add(DI_TTY, _writer())
+    return app
+
+
+class TestCommandResolution:
+    def test_later_module_overrides_earlier(self):
+        # system_modules are prepended to the module list, so overriding one of
+        # their commands is only possible if the later module wins
+        app = _app(SystemModule, AppModule)
+        assert app.resolve_command("db:update") == HERE + ".AppDbUpdateCmd"
+
+    def test_commands_that_are_not_overridden_are_kept(self):
+        app = _app(SystemModule, AppModule)
+        assert app.resolve_command("list") == HERE + ".SystemListCmd"
+        assert app.resolve_command("custom") == HERE + ".AppCustomCmd"
+
+    def test_unknown_command_resolves_to_none(self):
+        app = _app(SystemModule, AppModule)
+        assert app.resolve_command("no:such:command") is None
+
+    def test_command_map_holds_one_entry_per_name(self):
+        app = _app(SystemModule, AppModule)
+        cmd_map = app.get_command_map()
+        assert cmd_map["db:update"] == HERE + ".AppDbUpdateCmd"
+        assert len(cmd_map) == 3
+
+    def test_precedence_follows_load_order(self):
+        # reversing the load order reverses the winner: precedence is a property
+        # of the order, not of the modules
+        app = _app(AppModule, SystemModule)
+        assert app.resolve_command("db:update") == HERE + ".SystemDbUpdateCmd"
+
+    def test_no_modules(self):
+        app = _app()
+        assert app.get_command_map() == {}
+        assert app.resolve_command("list") is None
+
+
+class TestCommandDispatch:
+    def setup_method(self):
+        EXECUTED.clear()
+
+    def test_the_overriding_command_is_the_one_that_runs(self):
+        # the point of the whole change: resolution and execution must agree
+        app = _app(SystemModule, AppModule)
+        assert app.cli_runner("db:update", [], writer=_writer()) == app.CLI_CMD_SUCCESS
+        assert EXECUTED == ["app"]
+
+    def test_dispatch_follows_load_order(self):
+        app = _app(AppModule, SystemModule)
+        assert app.cli_runner("db:update", [], writer=_writer()) == app.CLI_CMD_SUCCESS
+        assert EXECUTED == ["system"]
+
+    def test_commands_that_are_not_overridden_still_dispatch(self):
+        app = _app(SystemModule, AppModule)
+        app.cli_runner("list", [], writer=_writer())
+        app.cli_runner("custom", [], writer=_writer())
+        assert EXECUTED == ["system-list", "app-custom"]
+
+    def test_unknown_command_reports_not_found(self):
+        app = _app(SystemModule, AppModule)
+        writer = _writer()
+        assert (
+            app.cli_runner("no:such:command", [], writer=writer)
+            == app.CLI_CMD_NOT_FOUND
+        )
+        assert EXECUTED == []
+        assert "command not found" in writer.stderr.getvalue()
+
+    def test_a_command_returning_false_reports_failure(self):
+        app = _app(FailingModule)
+        assert app.cli_runner("boom", [], writer=_writer()) == app.CLI_CMD_FAILED
+        assert EXECUTED == ["failing"]
+
+    def test_single_module_is_unaffected(self):
+        # the common case: one module, one declaration, nothing to override
+        app = _app(SystemModule)
+        assert app.cli_runner("db:update", [], writer=_writer()) == app.CLI_CMD_SUCCESS
+        assert EXECUTED == ["system"]
+
+
+class TestListingAgreesWithExecution:
+    def setup_method(self):
+        EXECUTED.clear()
+
+    def test_base_command_map_is_the_application_map(self):
+        app = _app(SystemModule, AppModule)
+        cmd = BaseCommand(app.di, writer=_writer())
+        assert cmd.get_cmd_map() == app.get_command_map()
+
+    def test_help_describes_the_class_that_would_run(self):
+        # before, help/list read the LAST declaration and cli_runner ran the FIRST
+        app = _app(SystemModule, AppModule)
+        writer = _writer()
+        assert HelpCmd(app.di, writer=writer).run(_Args("db:update")) is True
+        assert AppDbUpdateCmd.description in writer.stdout.getvalue()
+        assert SystemDbUpdateCmd.description not in writer.stdout.getvalue()
+
+    def test_list_shows_an_overridden_command_once(self):
+        app = _app(SystemModule, AppModule)
+        writer = _writer()
+        assert ListCmd(app.di, writer=writer).run(None) is True
+        out = writer.stdout.getvalue()
+        assert out.count("db:update") == 1
+        assert AppDbUpdateCmd.description in out
+        assert SystemDbUpdateCmd.description not in out
+
+    def test_every_listed_command_resolves_to_the_listed_class(self):
+        app = _app(SystemModule, AppModule, FailingModule)
+        cmd = BaseCommand(app.di, writer=_writer())
+        for name, path in cmd.get_cmd_map().items():
+            assert app.resolve_command(name) == path
+
+
+class _Args:
+    """Stand-in for the parsed argparse namespace HelpCmd expects."""
+
+    def __init__(self, command):
+        self.command = command

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ setenv =
     TEST_DB_USER=pokieUser
     TEST_DB_PASSWORD=somePassword
     REDIS_PASSWORD=myRedisPassword
+    # tox-docker already provides the services below; do not start a second set
+    POKIE_TEST_CONTAINERS=0
 
 [testenv:flake]
 commands = flake8 pokie/ tests/ setup.py


### PR DESCRIPTION
Two related changes: the first fixes command resolution, the second makes it possible to run the suite that proves it.

## 1. CLI commands resolve by module load order (last wins)

`cli_runner()` walked the module list and dispatched to the **first** module declaring a command. `get_cmd_map()` — what `list` and `help` are built from — built a dict by overwriting, so it returned the **last**. The two disagreed: an overridden command was *described* by one class and *executed* by another.

It also made overriding impossible where it matters. `build()` prepends `system_modules`, so `pokie.contrib.base` is always first and its commands always won — an application module could not replace `db:update` with its own, despite the comment in `build()` documenting later-overrides-earlier as the intended mechanism for customization (which is already how services behave).

- new `FlaskApplication.get_command_map()` / `resolve_command()`, the single source of truth
- `BaseCommand.get_cmd_map()` delegates to them, so listing, help and execution cannot drift apart again
- `BaseCommand.run()` no longer walks modules directly, so an overridden command is listed once instead of once per declaring module

**16 new tests** in `tests/unit/test_cli_override.py`, in three groups: resolution (precedence, load order, unknown commands), **dispatch** through `cli_runner()` — commands record a tag when they run, so the assertion is *which class executed*, not merely that something succeeded — and listing/help agreeing with execution.

## 2. Test services via testcontainers

Running the suite required a hand-provisioned PostgreSQL plus matching credentials in `env.sh`. That drifts, and when it does the **whole** suite fails rather than the database-backed part of it: `pokie_app` is autouse, so a stale password errors even tests that never touch a database. On my machine that was **195 errors**, `tests/unit` included.

`tests/conftest.py` now starts PostgreSQL and Redis for the session, so `python main.py pytest` needs nothing but Docker.

Two constraints shape the fixture:

- **session-scoped *and* autouse**, so it is set up before `pokie_app`. Nothing requests it explicitly, so without `autouse` it would never run.
- it sets **environment variables** rather than touching a built config, because `main.py` builds the application at import time, long before pytest starts. `pokie_app` re-runs `build_pokie()` whenever `TEST_SHARE_CTX` is false (the default), and that rebuild is what picks the values up.

CI and tox already start their own services, so both set `POKIE_TEST_CONTAINERS=0` and are otherwise untouched — a second set there is pure cost. Credentials are deliberately identical to theirs, so no test can come to depend on which mechanism provisioned it. Without `testcontainers` installed the fixture yields immediately and the environment is used as before, so `pip install .` without the dev extras still works.

## Verification

- `python main.py pytest` — **211 passed in 48.7s**, from 195 errors, with no `env.sh` sourced
- opt-out confirmed: `POKIE_TEST_CONTAINERS=0` with the old `env.sh` reproduces the previous password failure exactly, so no containers are started for CI/tox
- `flake8 --select=E9,F63,F7,F82,F811 pokie` (the CI gate) passes; flake8 is clean on all changed files
- `black --check` flags `pokie/core/application.py`, but the diff is entirely in pre-existing code (`pre_shutdown_hooks`, an event-validation message) and none of the additions here

## Notes

- **`psycopg2` is not declared anywhere in pokie's requirements** — it arrives transitively via rick-db, yet `pokie/contrib/base/cli/__init__.py` imports it unconditionally, so a fresh clone hits `ModuleNotFoundError` before any test runs. Not fixed here; worth adding explicitly.
- CI's `pull_request:` trigger only covers `master`, so this PR into `development` will not run the test workflow. Left alone rather than changed as a drive-by.

## Summary by Sourcery

Align CLI command resolution, listing, and help with module load order while making the test suite self-provision its backing services via testcontainers for local runs.

New Features:
- Introduce application-level command map and resolver APIs (`FlaskApplication.get_command_map()` and `FlaskApplication.resolve_command()`) as the single source of truth for CLI command resolution.
- Automatically provision PostgreSQL and Redis with testcontainers for local test runs when enabled, so `python main.py pytest` only requires Docker.

Bug Fixes:
- Ensure CLI commands resolve according to module load order with last declaration winning, so overridden application commands reliably replace system commands and execution matches what help/list describe.
- Make `BaseCommand` listing and help output use the same command map as CLI execution, preventing mismatches and duplicate entries for overridden commands.

Enhancements:
- Refactor CLI command dispatch in `FlaskApplication.cli_runner()` to delegate resolution through the centralized command map and handle unknown commands explicitly.
- Add focused unit tests covering CLI command precedence, dispatch behavior, and agreement between listing/help and execution.

CI:
- Configure CI and tox environments to disable local testcontainers usage in favor of their existing PostgreSQL and Redis services via `POKIE_TEST_CONTAINERS=0`.

Documentation:
- Update contributor documentation to describe container-based test service provisioning and the CLI command override semantics based on module load order.