### PR TITLE
Run CI on pull requests into development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [ master, development ]
   pull_request:
-    branches: [ master ]
+    # `branches` filters on the PR's BASE. Feature work is merged into
+    # development and development is merged into master, so listing master alone
+    # left every feature PR unchecked and only ran CI on the integration PR —
+    # the signal arrived after the code had landed, via the push trigger above.
+    branches: [ master, development ]
 
 permissions:
   contents: read


### PR DESCRIPTION
`pull_request.branches` filters on the PR's **base**, not its head:

```yaml
  pull_request:
    branches: [ master ]
```

Feature work is merged into `development`, and `development` is merged into `master`. So that filter meant **every feature PR ran no checks at all** — only the periodic `development → master` integration PR did. That inverts the intent: the change actually under review went unchecked, while the batch of already-merged ones got the gate.

CI did still run on the merge itself, via the `push: branches: [master, development]` trigger, so the signal existed — it just arrived after the code had landed.

One line:

```yaml
  pull_request:
    branches: [ master, development ]
```

## This is only half the problem

Neither branch is protected:

```
gh api repos/oddbit-project/pokie/branches/development/protection → 404 Branch not protected
gh api repos/oddbit-project/pokie/branches/master/protection      → 404 Branch not protected
```

So even where CI runs, nothing requires it to pass before a merge. The `ci-success` job (`ci.yml:125`) is built precisely to be that gate — `needs: [test, lint, build, security]`, `if: always()`, exits 1 on any failure or cancellation — and nothing consumes it.

Making it a **required status check** on `master` and `development` is a repository setting rather than a file, so it isn't in this PR. Without it this change buys visibility, not enforcement.

## Verification

Workflow parses; triggers and job graph confirmed:

```
push        : ['master', 'development']
pull_request: ['master', 'development']
jobs        : ['test', 'lint', 'build', 'security', 'ci-success']
ci-success needs: ['test', 'lint', 'build', 'security']
```

Note this change **cannot demonstrate itself**: for `pull_request` events GitHub selects eligible workflows from the **base** branch, so no CI run appears on this PR. It takes effect for PRs opened after it is merged into `development`.

Related: #15 (which is unchecked for exactly this reason).

## Summary by Sourcery

CI:
- Run CI checks on pull requests into the development branch in addition to master by adjusting the workflow trigger configuration.
