### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-07
+
 ### Fixed
 - Declare the PostgreSQL driver: `rick-db[pgsql-binary]` rather than bare `rick-db`. `pokie.contrib.base.cli.db` imports `rick_db.backend.pg` unconditionally and rick-db keeps psycopg2 behind an extra, so nothing installed it — `pip install pokie` then any CLI command (`list` included, since it loads every registered command class) raised `ModuleNotFoundError: No module named 'psycopg2'`. This is also why the CI test matrix has failed on every push since 1.1.0
 - CLI command resolution follows module load order, so a command declared by an application module now overrides one declared by an earlier module — the same precedence services already use. `cli_runner()` dispatched to the **first** module declaring a command while `list`/`help` described the **last**, so an overridden command was documented by one class and executed by another; and since `system_modules` (`pokie.contrib.base`) always load first, its commands could not be overridden at all
@@ -11,6 +13,7 @@
 
 ### Changed
 - The test suite provisions its own PostgreSQL and Redis with testcontainers, so `python main.py pytest` needs only Docker — no local PostgreSQL and no credentials in `env.sh`. Set `POKIE_TEST_CONTAINERS=0` to use services you provide instead (`TEST_DB_*` / `REDIS_*`), which is what CI and tox do since both already start their own. `testcontainers[postgres,redis]` is a dev dependency; without it installed the suite falls back to the environment as before
+- CI runs on pull requests into `development`, not only into `master`. `branches:` filters on the PR's base, so feature PRs — which target `development` — were never checked before merging; the first signal arrived from the push trigger after the code had already landed
 
 ## [1.1.1] - 2026-06-30
 

--- a/pokie/constants.py
+++ b/pokie/constants.py
@@ -1,5 +1,5 @@
 # Version
-POKIE_VERSION = ["1", "1", "1"]
+POKIE_VERSION = ["1", "2", "0"]
 
 
 def get_version():


### PR DESCRIPTION
Cuts 1.2.0 from `development`.

- `pokie/constants.py`: `POKIE_VERSION` → `1.2.0`
- `CHANGELOG.md`: `[Unreleased]` block moved under `## [1.2.0] - 2026-08-07`, fresh empty `[Unreleased]` left behind

Minor rather than patch: the release adds public API (`FlaskApplication.get_command_map()` / `resolve_command()`) and changes which class a shadowed CLI command dispatches to.

Contents, from the merged PRs:
- #15 CLI command override + testcontainers test services
- #16 CI on pull requests into `development`
- #17 declare `rick-db[pgsql-binary]` so psycopg2 is actually installed

The 1.2.0 entry also picks up the CI trigger fix, which #16 landed without a changelog line.

After merge: `development` → `master`, annotated tag `1.2.0` on `master`, then a GitHub Release to trigger `publish.yml` (PyPI) and `sbom.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cut 1.2.0 release from development, updating version metadata and documenting the included fixes and CI changes.

Bug Fixes:
- Document and ship the PostgreSQL driver extra so psycopg2 is installed with pokie, preventing ModuleNotFoundError in CLI commands.
- Align CLI command resolution with module load order so application modules can correctly override base commands and documentation matches execution.

Enhancements:
- Update test suite documentation for using testcontainers-managed PostgreSQL and Redis with a configurable fallback to external services.

Build:
- Bump POKIE_VERSION to 1.2.0 in constants for the new release.

CI:
- Run CI on pull requests targeting the development branch in addition to master.

Documentation:
- Add a 1.2.0 changelog entry and roll the previous Unreleased changes into this version.