### PR TITLE
Release 1.2.0 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-07
+
 ### Fixed
 - Declare the PostgreSQL driver: `rick-db[pgsql-binary]` rather than bare `rick-db`. `pokie.contrib.base.cli.db` imports `rick_db.backend.pg` unconditionally and rick-db keeps psycopg2 behind an extra, so nothing installed it — `pip install pokie` then any CLI command (`list` included, since it loads every registered command class) raised `ModuleNotFoundError: No module named 'psycopg2'`. This is also why the CI test matrix has failed on every push since 1.1.0
 - CLI command resolution follows module load order, so a command declared by an application module now overrides one declared by an earlier module — the same precedence services already use. `cli_runner()` dispatched to the **first** module declaring a command while `list`/`help` described the **last**, so an overridden command was documented by one class and executed by another; and since `system_modules` (`pokie.contrib.base`) always load first, its commands could not be overridden at all
@@ -11,6 +13,7 @@
 
 ### Changed
 - The test suite provisions its own PostgreSQL and Redis with testcontainers, so `python main.py pytest` needs only Docker — no local PostgreSQL and no credentials in `env.sh`. Set `POKIE_TEST_CONTAINERS=0` to use services you provide instead (`TEST_DB_*` / `REDIS_*`), which is what CI and tox do since both already start their own. `testcontainers[postgres,redis]` is a dev dependency; without it installed the suite falls back to the environment as before
+- CI runs on pull requests into `development`, not only into `master`. `branches:` filters on the PR's base, so feature PRs — which target `development` — were never checked before merging; the first signal arrived from the push trigger after the code had already landed
 
 ## [1.1.1] - 2026-06-30
 

--- a/pokie/constants.py
+++ b/pokie/constants.py
@@ -1,5 +1,5 @@
 # Version
-POKIE_VERSION = ["1", "1", "1"]
+POKIE_VERSION = ["1", "2", "0"]
 
 
 def get_version():


### PR DESCRIPTION
Promotes `development` to `master` for the 1.2.0 tag.

Delta since `master` (`c91e33e`): the release commit only — `POKIE_VERSION` → `1.2.0` and the `CHANGELOG.md` `[Unreleased]` → `[1.2.0]` move. Everything else was already promoted in #18.

`master` has had no CI run of its own since #18: the push event was dropped during the GitHub Actions outage on 2026-08-06, and `ci.yml` has no `workflow_dispatch`. Merging this restores a push-triggered run on `master`, which is also the prerequisite for requiring `CI Success` in branch protection.

Green on `development` at `875f70d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release version 1.2.0 and update documentation accordingly.

Enhancements:
- Update the application version constant to 1.2.0.

Documentation:
- Finalize the 1.2.0 entry in the changelog, moving it from Unreleased with its associated notes.